### PR TITLE
Add Default Icon Title

### DIFF
--- a/packages/react-icons/src/iconBase.tsx
+++ b/packages/react-icons/src/iconBase.tsx
@@ -66,7 +66,7 @@ export function IconBase(
         width={computedSize}
         xmlns="http://www.w3.org/2000/svg"
       >
-        {title && <title>{title}</title>}
+        {<title>{title || "Icon"}</title>}
         {props.children}
       </svg>
     );


### PR DESCRIPTION
This PR adds a default "Icon" title to icon svgs in the event users do not provide an icon title so that icons are ALWAYS accessible by screen readers and other assistive technologies.